### PR TITLE
wip

### DIFF
--- a/docs/App.svelte
+++ b/docs/App.svelte
@@ -11,6 +11,7 @@
 	import GettingStarted from "./GettingStarted.svx";
 	import TextDocs from "./Text.svx";
 	import LinkDocs from "./Link.svelte";
+	import FormFieldDocs from "./FormField.svelte";
 
 	// Doc Components
 	import Header from "./components/Header.svelte";
@@ -54,6 +55,9 @@
 		</Route>
 		<Route path="/components/link">
 			<LinkDocs />
+		</Route>
+		<Route path="/components/form-field">
+			<FormFieldDocs />
 		</Route>
 		<Route path="/examples/apple-music">
 			<AppleMusic />

--- a/docs/FormField.svelte
+++ b/docs/FormField.svelte
@@ -1,0 +1,126 @@
+<script>
+	import Prism from "svelte-prism";
+	import {
+		Box,
+		Button,
+		Control,
+		Divider,
+		Field,
+		Label,
+		Stack,
+		Text,
+		Link,
+		FormField,
+	} from "../src/components/index.js";
+	import PageHeader from "./components/PageHeader.svelte";
+
+	let selectedType = "default";
+	$: elementExample = `<FormField
+  type="${selectedType}"
+>
+  Link
+</FormField>
+`;
+
+	function resetControls() {
+		selectedType = "default";
+	}
+</script>
+
+<style lang="scss">
+	@use "../src/scss/utils/all" as *;
+
+	.playground {
+		display: grid;
+		grid-template-columns: 1fr 15rem;
+		grid-gap: var(--space-2);
+		height: 100vh;
+
+		&__example {
+			overflow: hidden;
+			padding: var(--space-4);
+		}
+
+		&__code {
+			tab-size: 2;
+		}
+
+		&__radios {
+			display: flex;
+			flex-direction: column;
+		}
+	}
+</style>
+
+<div class="playground">
+	<div class="playground__example">
+		<FormField>
+			<label slot="label">Filter</label>
+			<input slot="input" type="search" />
+		</FormField>
+	</div>
+	<div class="playground__controls">
+		<Stack space="1">
+			<PageHeader title="FormField" desc="A form component, used for inputs." />
+
+			<!-- Controls -->
+			<Box>
+				<Text weight="bold">Controls</Text>
+
+				<!-- New Form Control Components -->
+				<Stack>
+					<!-- Type -->
+					<Field>
+						<Control label="Type">
+							<div class="playground__radios">
+								<label>
+									<input
+										type="radio"
+										bind:group="{selectedType}"
+										value="default"
+									/>
+									default
+								</label>
+								<label>
+									<input
+										type="radio"
+										bind:group="{selectedType}"
+										value="article"
+									/>
+									article
+								</label>
+								<label>
+									<input
+										type="radio"
+										bind:group="{selectedType}"
+										value="implied"
+									/>
+									implied
+								</label>
+							</div>
+						</Control>
+					</Field>
+				</Stack>
+
+				<Button on:click="{resetControls}">Reset</Button>
+			</Box>
+
+			<Divider />
+
+			<!-- Import Instructions-->
+			<Box>
+				<Text weight="bold">Use</Text>
+				<Text>{`import { FormField } from "union-design-system"`}</Text>
+			</Box>
+
+			<Divider />
+
+			<div class="playground__code">
+				<Box>
+					<Text weight="bold">Code</Text>
+					<Prism language="html" source="{elementExample}" />
+				</Box>
+			</div>
+		</Stack>
+	</div>
+</div>

--- a/docs/components/Nav.svelte
+++ b/docs/components/Nav.svelte
@@ -49,6 +49,11 @@
 						<Link to="/components/link" type="implied">Link</Link>
 					</Text>
 				</ListItem>
+				<ListItem>
+					<Text>
+						<Link to="/components/form-field" type="implied">FormField</Link>
+					</Text>
+				</ListItem>
 			</List>
 		</NavigationSection>
 		<!--

--- a/src/components/FormField.svelte
+++ b/src/components/FormField.svelte
@@ -1,0 +1,18 @@
+<style lang="scss">
+	@use "../scss/forms/_forms" as *;
+</style>
+
+<div class="un-field">
+	<slot name="label" />
+	<div class="un-control">
+		<slot name="input" />
+		<!-- <input
+			formControlName="vendor"
+			class="un-input"
+			type="text"
+			placeholder="Ex. Trader Joe's"
+			value=""
+			[class.input-error]="vendor.invalid && (vendor.touched || vendor.dirty)"
+		/> -->
+	</div>
+</div>

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -4,6 +4,7 @@ export { default as Control } from "./Control.svelte";
 export { default as Divider } from "./Divider.svelte";
 export { default as FixedImage } from "./FixedImage.svelte";
 export { default as Field } from "./Field.svelte";
+export { default as FormField } from "./FormField.svelte";
 export { default as Frame } from "./Frame.svelte";
 export { default as Inline } from "./Inline.svelte";
 export { default as Label } from "./Label.svelte";

--- a/src/scss/forms/_forms.scss
+++ b/src/scss/forms/_forms.scss
@@ -1,0 +1,146 @@
+/// Form Control Mixins
+///
+// Creates standardized mixins for form elements
+@use "../utils/all" as *;
+
+// Control - Sets foundation for all control elements
+$control-height: grid-8pt(7);
+$control-line-height: 1.5;
+$control-padding-horizontal: var(--space-3);
+$control-padding-vertical: var(--space-3);
+$control-radius: var(--size-border-radius-2);
+$control-border-width: var(--size-border-1);
+$control-font-size: 1rem;
+
+@mixin control {
+	display: inline-flex;
+	align-items: center;
+	justify-content: flex-start;
+	height: $control-height;
+	border: $control-border-width solid transparent;
+	border-radius: $control-radius;
+	padding: 0 $control-padding-horizontal;
+	position: relative;
+	font-size: $control-font-size;
+	line-height: $control-line-height;
+
+	&[disabled],
+	fieldset[disabled] & {
+		cursor: not-allowed;
+	}
+}
+
+// Placeholder - Automates generation of placeholder text styling
+@mixin placeholder {
+	$placeholders: ":-moz" ":-webkit-input" "-moz" "-ms-input";
+
+	@each $placeholder in $placeholders {
+		&:#{$placeholder}-placeholder {
+			@content;
+		}
+	}
+}
+
+// Field - Creates a wrapper container for form controls
+@mixin field {
+	margin-bottom: var(--space-3);
+}
+
+@mixin field-horizontal {
+	display: flex;
+	flex-wrap: wrap;
+	margin-bottom: var(--space-3);
+
+	* + *:not(:last-child) {
+		margin-right: var(--space-2);
+	}
+
+	.un-label {
+		flex: 0 0 100%;
+	}
+
+	.un-control {
+		flex: 0 0 calc(50% - 4px);
+	}
+}
+
+.un-field {
+	@include field;
+}
+
+.un-field-horizontal {
+	@include field-horizontal;
+}
+
+// Label - Labels for form controls
+@mixin label {
+	@include text-preset(2);
+
+	color: $text-subtle;
+	display: block;
+	font-weight: $weight-medium;
+	line-height: baseline-scale(3);
+}
+
+.un-label {
+	@include label;
+
+	height: baseline-scale(3);
+	display: flex;
+}
+
+// Input - Sets styling and shareable state to input contols
+$input-background: $white;
+$input-color: $text;
+$input-border-color: $blue-grey-200;
+
+$input-focus-box-shadow-size: 0 0 2px 0.125em;
+$input-focus-border-color: $link;
+$input-focus-box-shadow-color: $link;
+
+$input-disabled-background-color: $blue-grey-100;
+$input-disabled-border-color: $blue-grey-300;
+$input-disabled-color: $blue-grey-300;
+$input-disabled-placeholder-color: $blue-grey-300;
+
+$input-placeholder-color: $blue-grey-500;
+
+@mixin input {
+	@include control;
+
+	background: $input-background;
+	color: $input-color;
+	border-color: $input-border-color;
+	transition: all $speed-fastest ease-in-out;
+	width: 100%;
+
+	@include placeholder {
+		color: $input-placeholder-color;
+		font-weight: $weight-light;
+	}
+
+	&:focus,
+	&.is-focused,
+	&:active,
+	&.is-active {
+		box-shadow: $input-focus-box-shadow-size
+			rgba($input-focus-box-shadow-color, 0.25);
+	}
+
+	&[disabled],
+	fieldset[disabled] & {
+		background-color: $input-disabled-background-color;
+		border-color: $input-disabled-border-color;
+		box-shadow: none;
+		color: $input-disabled-color;
+
+		@include placeholder {
+			color: $input-disabled-placeholder-color;
+		}
+	}
+}
+
+// Standard Inputs
+.un-input {
+	@include input;
+}


### PR DESCRIPTION
started with making a text input

i referenced the work in ems-gui, angular material, the other parts of union...

i saw the "Field" component in union, which might be the same thing in spirit as the "FormField" in this PR.

you'll notice the pillaging.

the stopping point was replacing "$text-subtle" because in ems-gui its a reference to a derived blue variable. here it would need to reference a theme.

trash is trash. this is not meant to be merged.

has anything come from this? we chatted about the depth of work that goes into making interactive docs being a trade-off to making the components themselves. after looking at the complexity of angular materials form-field, it's clearer now that the focus on the components themselves is the best use of effort in the beginning. 